### PR TITLE
support for older browsers that don't show ✓ or ✗

### DIFF
--- a/src/sink.css
+++ b/src/sink.css
@@ -31,11 +31,12 @@ li {
   padding: 5px;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
+  border-radius: 5px;
   overflow: hidden;
+  cursor: pointer;
 }
 ol > li {
   opacity: 0;
-  cursor: pointer;
   background-color: lightblue;
   color: #000;
 }
@@ -67,6 +68,10 @@ li ul {
   margin: 0;
   padding: 0;
   list-style: none;
+  position: relative; /*early IE overflow bug*/
+}
+li ul.show {
+  position: static; /*early IE overflow bug*/
 }
 li.pass ul.show {
   background-color: #8fffa3;
@@ -79,13 +84,14 @@ li ul.show {
   padding: 5px;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
+  border-radius: 5px;
   margin: 5px;
 }
 li ul li {
-  padding: 0;
+  padding: 3px 6px;
   margin: 2px 0;
   list-style: none;
-  position: relative;
+  font-size: 15px;
 }
 li b {
   display: block;

--- a/src/sink.js
+++ b/src/sink.js
@@ -139,6 +139,7 @@
       else console.log(logKey + msg + (message + ' ✗').red)
     } else {
       var li = document.createElement('li')
+      li.className = b ? 'pass' : 'fail'
       li.innerHTML = msg + ' ' + message + ' ' + '<em class="marker">' + (b ? '✓' : '✗') + '</em>'
       item.appendChild(li)
     }
@@ -153,6 +154,7 @@
       else console.log(logKey + (message + ' ✗').red)
     } else {
       var li = document.createElement('li')
+      li.className = b ? 'pass' : 'fail'
       li.innerHTML = message + ' ' + (b ? '✓' : '✗')
       item.appendChild(li)
     }


### PR DESCRIPTION
Fixes for older browsers that don't properly show the special characters. Up to IE8 show them as little boxes and you can't distinguish between pass and fail so you don't know which subtest if failing. Even FF up to 3.6 (I haven't tested 4) doesn't show them properly (but at least what it does show has a very slight difference between tick and cross).

This pull request puts the 'pass' and 'fail' classes into the subtest <LI> elements so they can be styled accordingly and it doesn't matter what the indicator character is, the red/green tells you everything.

There's also some other minor CSS fixes for older browsers, particularly IE.

Here's what the worst browser, IE6, looks like before:
![IE6 before](http://js.vagg.org/github/sink_ie6_before.png)

And after:
![IE6 before](http://js.vagg.org/github/sink_ie6_after.png)

(those are bonzo tests, note I had to put (X) inside the notes on the failing tests to show which ones are broken cause I couldn't tell).

This should fix issue #4 from @tmcw
